### PR TITLE
add mixin-font

### DIFF
--- a/src/sass/utils/_templates.scss
+++ b/src/sass/utils/_templates.scss
@@ -1,0 +1,7 @@
+
+@mixin font($fw, $fs, $lh) {
+    font-weight: $fw;
+    font-size: $fs+px;
+    line-height: calc(#{$lh} / #{$fs});
+}
+


### PR DESCRIPTION
letter-spaсing я решил в миксин не включать, т.к. он по макету везде, вижу, одинаковый 8%. Его можно просто в body указать. И только в заголовках секций он 3%.